### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-cicd-publish.yml
+++ b/.github/workflows/dotnet-cicd-publish.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/angelobelchior/TheMediator/security/code-scanning/1](https://github.com/angelobelchior/TheMediator/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added to the workflow or job definition, specifying the minimum set of permissions the workflow needs to operate. For this particular workflow, the job only needs to check out code and publish a NuGet package using a secret; it does not appear to require write access to repository content, nor to issues, pull requests, or deployment environments. Therefore, setting `contents: read` at the job or workflow root level is adequate, as a starting point. You should add:

```yaml
permissions:
  contents: read
```

at the root level—above `jobs:`—in `.github/workflows/dotnet-cicd-publish.yml`. If later steps require additional permissions (such as for releases, deployments, etc.), only the minimum additional scopes should be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
